### PR TITLE
add Giton to standard model

### DIFF
--- a/standard_model.md
+++ b/standard_model.md
@@ -19,3 +19,4 @@ The Standard Model of Particle Physics
 | W boson       | W      | 1    | ±1      | 80.4                    |
 | gluon         | g      | 1    | 0       | 0                       |
 | Higgs boson   | H      | 0    | 0       | 125                     |
+| Giton         | G      | 2    | 0       | 750                     |


### PR DESCRIPTION
New particle:
Giton, with symbol G, spin 2, charge 0, and mass 750 GeV. 